### PR TITLE
Add destinations data and detail pages

### DIFF
--- a/src/app/destinations/[slug]/page.jsx
+++ b/src/app/destinations/[slug]/page.jsx
@@ -1,0 +1,28 @@
+import destinations from "@/data/destinations";
+import { notFound } from "next/navigation";
+
+export function generateStaticParams() {
+  return destinations.map((d) => ({ slug: d.slug }));
+}
+
+export default function DestinationPage({ params }) {
+  const destination = destinations.find((d) => d.slug === params.slug);
+
+  if (!destination) {
+    notFound();
+  }
+
+  return (
+    <main className="mx-auto max-w-4xl px-4 py-10">
+      <h1 className="text-3xl md:text-4xl font-medium">{destination.title}</h1>
+      <img
+        src={destination.image}
+        alt=""
+        className="mt-6 w-full rounded-xl object-cover"
+      />
+      {destination.details && (
+        <p className="mt-4 text-lg leading-relaxed">{destination.details}</p>
+      )}
+    </main>
+  );
+}

--- a/src/components/Destinations.jsx
+++ b/src/components/Destinations.jsx
@@ -1,33 +1,24 @@
-const items = [
-  { title: "Tokyo", img: "https://picsum.photos/seed/tokyo/1200/800" },
-  { title: "Kyoto", img: "https://picsum.photos/seed/kyoto/1200/800" },
-  {
-    title: "Hakone / Mt Fuji",
-    img: "https://picsum.photos/seed/fuji/1200/800",
-  },
-  { title: "Miyajima", img: "https://picsum.photos/seed/miyajima/1200/800" },
-  { title: "Nara", img: "https://picsum.photos/seed/nara/1200/800" },
-  { title: "Kanazawa", img: "https://picsum.photos/seed/kanazawa/1200/800" },
-];
+import Link from "next/link";
+import destinations from "@/data/destinations";
 
 export default function Destinations() {
   return (
     <section id="destinations" className="mx-auto max-w-6xl px-4 py-16">
       <div className="flex items-end justify-between">
         <h2 className="text-3xl md:text-4xl font-medium">Destinations</h2>
-        <a href="#" className="underline">
+        <Link href="/destinations" className="underline">
           View all
-        </a>
+        </Link>
       </div>
       <div className="mt-8 grid gap-4 sm:grid-cols-2 md:grid-cols-3">
-        {items.map((d) => (
-          <a
-            key={d.title}
-            href="#"
+        {destinations.map((d) => (
+          <Link
+            key={d.slug}
+            href={`/destinations/${d.slug}`}
             className="group relative overflow-hidden rounded-xl"
           >
             <img
-              src={d.img}
+              src={d.image}
               alt=""
               className="h-64 w-full object-cover transition duration-300 group-hover:scale-105"
             />
@@ -35,7 +26,7 @@ export default function Destinations() {
             <div className="absolute bottom-3 left-3 text-white text-lg font-medium">
               {d.title}
             </div>
-          </a>
+          </Link>
         ))}
       </div>
     </section>

--- a/src/data/destinations.js
+++ b/src/data/destinations.js
@@ -1,0 +1,52 @@
+const destinations = [
+  {
+    title: "Tokyo",
+    slug: "tokyo",
+    image: "https://picsum.photos/seed/tokyo/1200/800",
+    summary: "Japan's bustling capital city",
+    details:
+      "Tokyo blends cutting-edge modernity with traditional temples and tranquil gardens.",
+  },
+  {
+    title: "Kyoto",
+    slug: "kyoto",
+    image: "https://picsum.photos/seed/kyoto/1200/800",
+    summary: "Historic city of shrines and geisha",
+    details:
+      "Once Japan's capital, Kyoto is home to thousands of classical Buddhist temples and gardens.",
+  },
+  {
+    title: "Hakone / Mt Fuji",
+    slug: "hakone-mt-fuji",
+    image: "https://picsum.photos/seed/fuji/1200/800",
+    summary: "Scenic gateway to Japan's iconic mountain",
+    details:
+      "Relax in hot springs and take in views of Mt Fuji across Lake Ashi and the surrounding national park.",
+  },
+  {
+    title: "Miyajima",
+    slug: "miyajima",
+    image: "https://picsum.photos/seed/miyajima/1200/800",
+    summary: "Island of the floating torii gate",
+    details:
+      "Miyajima is famed for Itsukushima Shrine, where a vermilion gate appears to float at high tide.",
+  },
+  {
+    title: "Nara",
+    slug: "nara",
+    image: "https://picsum.photos/seed/nara/1200/800",
+    summary: "Ancient capital with free-roaming deer",
+    details:
+      "Nara offers monumental temples and friendly deer wandering through expansive parks.",
+  },
+  {
+    title: "Kanazawa",
+    slug: "kanazawa",
+    image: "https://picsum.photos/seed/kanazawa/1200/800",
+    summary: "Preserved samurai and geisha districts",
+    details:
+      "Kanazawa boasts well-preserved Edo-era neighborhoods and the famed Kenrokuen Garden.",
+  },
+];
+
+export default destinations;


### PR DESCRIPTION
## Summary
- move destination information into shared data file
- link destination cards to new dynamic detail pages
- pre-build destination detail routes with `generateStaticParams`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2a898ef3483239500ba156295e124